### PR TITLE
added package.json, including the original authors name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "The Shell",
+  "version": "0.1.0",
+  "author" : "mityalebedev",
+  "description" : "Simple theme for Ghost. Pure CSS. Web Safe fonts."
+}


### PR DESCRIPTION
Since [Ghost have begun to require that this file is included](https://themes.ghost.org/docs/templates#section-package-json) in the theme package, I made it.
