### PR TITLE
Added Ghost 2.0 figure.kg-width-full and related css properties.

### DIFF
--- a/assets/css/normalize.css
+++ b/assets/css/normalize.css
@@ -252,6 +252,26 @@ figure {
     margin: 0;
 }
 
+.post .kg-width-wide .kg-image {
+  max-width: 900px;
+  width: 900px;
+}
+
+figure.kg-width-full {
+  max-width: 100vw;
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+}
+
+figure.kg-width-full .kg-image {
+  max-width: 100vw;
+  width: 100vw;
+}
+
 /* ==========================================================================
    Forms
    ========================================================================== */

--- a/assets/css/normalize.css
+++ b/assets/css/normalize.css
@@ -252,6 +252,12 @@ figure {
     margin: 0;
 }
 
+figcaption {
+  text-align: center;
+  margin-top: -12px;
+  padding: 0.5rem;
+}
+
 .post .kg-width-wide .kg-image {
   max-width: 900px;
   width: 900px;
@@ -268,8 +274,8 @@ figure.kg-width-full {
 }
 
 figure.kg-width-full .kg-image {
-  max-width: 100vw;
-  width: 100vw;
+  max-width: 95vw;
+  width: 95vw;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
This will allow for images to be set to wide and full size using the new Ghost 2.0 css related properties.

Further details can be found here: https://docs.ghost.org/api/handlebars-themes/editor/#image-size-options

Signed-off-by: travis <travisneely@gmail.com>